### PR TITLE
Update default devnet sector size

### DIFF
--- a/build/buildconstants/params_2k.go
+++ b/build/buildconstants/params_2k.go
@@ -102,7 +102,7 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	0: DrandQuicknet,
 }
 
-var ConsensusMinerMinPower = abi.NewStoragePower(2048)
+var ConsensusMinerMinPower = abi.NewStoragePower(512 << 20)
 var PreCommitChallengeDelay = abi.ChainEpoch(10)
 
 func init() {

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -121,7 +121,7 @@ var DefaultRemainderAccountActor = genesis.Actor{
 func NewGeneratorWithSectorsAndUpgradeSchedule(numSectors int, us stmgr.UpgradeSchedule) (*ChainGen, error) {
 	j := journal.NilJournal()
 	// TODO: we really shouldn't modify a global variable here.
-	policy.SetSupportedProofTypes(abi.RegisteredSealProof_StackedDrg2KiBV1)
+	policy.SetSupportedProofTypes(abi.RegisteredSealProof_StackedDrg512MiBV1)
 
 	mr := repo.NewMemory(nil)
 	lr, err := mr.Lock(repo.StorageMiner)

--- a/scripts/devnet.bash
+++ b/scripts/devnet.bash
@@ -65,7 +65,7 @@ cat > "${BASEDIR}/scripts/create_miner.bash" <<EOF
 set -x
 
 lotus wallet import --as-default ~/.genesis-sectors/pre-seal-t01000.key
-lotus-miner init --genesis-miner --actor=t01000 --sector-size=2KiB --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t01000.json --nosync
+lotus-miner init --genesis-miner --actor=t01000 --sector-size=512MiB --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t01000.json --nosync
 EOF
 
 cat > "${BASEDIR}/scripts/pledge_sectors.bash" <<EOF
@@ -178,7 +178,7 @@ tmux send-keys -t $session:$wcli      "source ${BASEDIR}/scripts/env.$shell" C-m
 tmux send-keys -t $session:$wpledging "source ${BASEDIR}/scripts/env.$shell" C-m
 tmux send-keys -t $session:$wshell "source ${BASEDIR}/scripts/env.$shell" C-m
 
-tmux send-keys -t $session:$wdaemon "lotus-seed pre-seal --sector-size 2KiB --num-sectors 2" C-m
+tmux send-keys -t $session:$wdaemon "lotus-seed pre-seal --sector-size 512MiB --num-sectors 2" C-m
 tmux send-keys -t $session:$wdaemon "lotus-seed genesis new devnet.json" C-m
 tmux send-keys -t $session:$wdaemon "lotus-seed genesis add-miner devnet.json ~/.genesis-sectors/pre-seal-t01000.json" C-m
 tmux send-keys -t $session:$wdaemon "lotus daemon --api 48010 --lotus-make-genesis=dev.gen --genesis-template=devnet.json --bootstrap=false 2>&1 | tee -a ${BASEDIR}/daemon.log" C-m

--- a/scripts/init-network.sh
+++ b/scripts/init-network.sh
@@ -3,7 +3,7 @@
 set -xeo
 
 NUM_SECTORS=2
-SECTOR_SIZE=2KiB
+SECTOR_SIZE=512MiB
 
 
 sdt0111=$(mktemp -d)


### PR DESCRIPTION
## Summary
- use 512MiB sector size for scripts and params
- adjust default proof type used in chain generator

## Testing
- `make unittests` *(fails: extern/filecoin-ffi/go.mod: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687a1ab4e05883218f5334359847403a