### PR TITLE
Use 512MiB sectors for local nets

### DIFF
--- a/scripts/dev/gen-daemon
+++ b/scripts/dev/gen-daemon
@@ -5,7 +5,7 @@ set -o xtrace
 export TRUST_PARAMS=1
 tag=${TAG:-debug}
 
-go run -tags=$tag ./cmd/lotus-seed pre-seal --sector-size 2KiB --num-sectors 2
+go run -tags=$tag ./cmd/lotus-seed pre-seal --sector-size 512MiB --num-sectors 2
 go run -tags=$tag ./cmd/lotus-seed genesis new localnet.json
 go run -tags=$tag ./cmd/lotus-seed genesis add-miner localnet.json ~/.genesis-sectors/pre-seal-t01000.json
 go run -tags=$tag ./cmd/lotus daemon --lotus-make-genesis=devel.gen --genesis-template=localnet.json --bootstrap=false

--- a/scripts/devnet.bash
+++ b/scripts/devnet.bash
@@ -65,7 +65,7 @@ cat > "${BASEDIR}/scripts/create_miner.bash" <<EOF
 set -x
 
 lotus wallet import --as-default ~/.genesis-sectors/pre-seal-t01000.key
-lotus-miner init --genesis-miner --actor=t01000 --sector-size=2KiB --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t01000.json --nosync
+lotus-miner init --genesis-miner --actor=t01000 --sector-size=512MiB --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t01000.json --nosync
 EOF
 
 cat > "${BASEDIR}/scripts/pledge_sectors.bash" <<EOF
@@ -178,7 +178,7 @@ tmux send-keys -t $session:$wcli      "source ${BASEDIR}/scripts/env.$shell" C-m
 tmux send-keys -t $session:$wpledging "source ${BASEDIR}/scripts/env.$shell" C-m
 tmux send-keys -t $session:$wshell "source ${BASEDIR}/scripts/env.$shell" C-m
 
-tmux send-keys -t $session:$wdaemon "lotus-seed pre-seal --sector-size 2KiB --num-sectors 2" C-m
+tmux send-keys -t $session:$wdaemon "lotus-seed pre-seal --sector-size 512MiB --num-sectors 2" C-m
 tmux send-keys -t $session:$wdaemon "lotus-seed genesis new devnet.json" C-m
 tmux send-keys -t $session:$wdaemon "lotus-seed genesis add-miner devnet.json ~/.genesis-sectors/pre-seal-t01000.json" C-m
 tmux send-keys -t $session:$wdaemon "lotus daemon --api 48010 --lotus-make-genesis=dev.gen --genesis-template=devnet.json --bootstrap=false 2>&1 | tee -a ${BASEDIR}/daemon.log" C-m

--- a/scripts/init-network.sh
+++ b/scripts/init-network.sh
@@ -3,7 +3,7 @@
 set -xeo
 
 NUM_SECTORS=2
-SECTOR_SIZE=2KiB
+SECTOR_SIZE=512MiB
 
 
 sdt0111=$(mktemp -d)


### PR DESCRIPTION
## Summary
- update local network scripts to use 512MiB sectors

## Testing
- `bash -n scripts/init-network.sh scripts/devnet.bash scripts/dev/gen-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687a1f7e10348321939d05f18f9e6b53