### PR TITLE
docs(nomad): set listen addresses via environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 - fix(cli): make lotus-miner sectors extend command resilient to higher gas ([filecoin-project/lotus#11927](https://github.com/filecoin-project/lotus/pull/11928))
 - feat(api): update go-f3 to 0.8.8, add F3GetPowerTableByInstance to the API ([filecoin-project/lotus#13201](https://github.com/filecoin-project/lotus/pull/13201))
 - fix(cli): use F3GetPowerTableByInstance to resolve F3 power tables by default, `--by-tipset` flag can be used to restore old behavior ([filecoin-project/lotus#13201](https://github.com/filecoin-project/lotus/pull/13201))
+- docs: update Nomad example for running Lotus on Calibnet with host paths
+- docs: Nomad example automatically fetches the latest Calibnet snapshot
+- docs: Nomad job runs inline script with optional `FILECOIN_SNAPSHOT`
+- docs: Nomad job sets `LOTUS_API_LISTENADDRESS` and `LOTUS_LIBP2P_LISTENADDRESSES`
 
 # Node v1.33.0 / 2025-05-08
 The Lotus v1.33.0 release introduces experimental v2 APIs with F3 awareness, featuring a new TipSet selection mechanism that significantly enhances how applications interact with the Filecoin blockchain. This release candidate also adds F3-aware Ethereum APIs via the /v2 endpoint.  All of the /v2 APIs implement intelligent fallback mechanisms between F3 and Expected Consensus and are exposed through the Lotus Gateway.

--- a/documentation/en/nomad-calibnet.md
+++ b/documentation/en/nomad-calibnet.md
@@ -1,0 +1,31 @@
+# Running a Lotus full node on Calibnet with Nomad
+
+This guide shows how to compile Lotus for Calibnet and launch it using a Nomad job.
+
+## Build Lotus
+
+Compile Lotus with the `calibnet` build tag and install it:
+
+```bash
+make clean calibnet
+sudo make install
+```
+
+The `lotus` binary will be installed to `/usr/local/bin`.
+
+## Nomad job file
+
+The `nomad/lotus-calibnet.nomad` file starts a single Lotus daemon task using the `raw_exec` driver. Because `raw_exec` cannot mount volumes, the job expects the `/opt/lotus` repo and `/var/tmp/filecoin-proof-parameters` directory to already exist on the host.
+The task runs a small inline script that imports a snapshot the first time the node starts. If the `FILECOIN_SNAPSHOT` environment variable is set, that path or URL is imported; otherwise the script fetches the latest Calibnet snapshot from `https://forest-archive.chainsafe.dev/latest/calibnet/`.
+The job runs in the `ict-staging` namespace on the `hetzner` datacenter and pins the task to `hetzner-staging-calibnet-node`.
+The daemon is started without command-line flags; instead the job sets `LOTUS_API_LISTENADDRESS` and `LOTUS_LIBP2P_LISTENADDRESSES` so the API listens on port `1234` and the libp2p swarm on port `4012`.
+The task registers a health-checked service and restarts with exponential backoff if it crashes.
+The example configuration requests 30 CPU cores and 100&nbsp;GiB of RAM.
+
+```bash
+nomad run nomad/lotus-calibnet.nomad
+```
+
+The script fetches the snapshot only on the initial start and writes a flag file to `$LOTUS_PATH/date_initialized` after a successful import so subsequent restarts skip the download.
+
+Adjust the datacenter, node constraint, or resource requirements in the job file as needed for your environment.

--- a/nomad/lotus-calibnet.nomad
+++ b/nomad/lotus-calibnet.nomad
@@ -1,0 +1,77 @@
+job "lotus-calibnet" {
+  namespace   = "ict-staging"
+  datacenters = ["hetzner"]
+  type        = "service"
+
+  constraint {
+    attribute = "${node.unique.name}"
+    operator  = "="
+    value     = "hetzner-staging-calibnet-node"
+  }
+
+  group "lotus" {
+    network {
+      port "api" { static = 1234 }
+      port "p2p" { to = 4012 }
+    }
+
+    task "daemon" {
+      driver = "raw_exec"
+
+      config {
+        command = "/bin/bash"
+        args    = [
+          "-ec",
+          <<-EOF
+            SNAPSHOT_URL="${FILECOIN_SNAPSHOT:-https://forest-archive.chainsafe.dev/latest/calibnet/}"
+            GATE="$LOTUS_PATH/date_initialized"
+            if [ ! -f "$GATE" ]; then
+              echo "Importing snapshot from $SNAPSHOT_URL"
+              if echo "$SNAPSHOT_URL" | grep -q '^https\?://'; then
+                curl -sL "$SNAPSHOT_URL" | /usr/local/bin/lotus daemon --import-snapshot - --halt-after-import
+              else
+                /usr/local/bin/lotus daemon --import-snapshot "$SNAPSHOT_URL" --halt-after-import
+              fi
+              date > "$GATE"
+            fi
+            exec /usr/local/bin/lotus daemon
+          EOF
+        ]
+      }
+
+      env {
+        LOTUS_PATH                 = "/opt/lotus"
+        FIL_PROOFS_PARAMETER_CACHE = "/var/tmp/filecoin-proof-parameters"
+        LOTUS_API_LISTENADDRESS      = "/ip4/0.0.0.0/tcp/${NOMAD_PORT_api}/http"
+        LOTUS_LIBP2P_LISTENADDRESSES = "/ip4/0.0.0.0/tcp/${NOMAD_PORT_p2p}"
+        LOTUS_NETWORK              = "calibration"
+        LOTUS_FD_MAX               = "1048576"
+      }
+      resources {
+        # needs 30 vCPU on the node
+        cpu    = 30000
+        # 100 GiB
+        memory = 102400
+      }
+
+      service {
+        name = "lotus-calib-api"
+        port = "api"
+        tags = ["filecoin", "lotus", "calibnet"]
+
+        check {
+          type     = "tcp"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+
+      restart {
+        attempts = 10
+        interval = "5m"
+        delay    = "30s"
+        mode     = "delay"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- update the Nomad job to set `LOTUS_API_LISTENADDRESS` and `LOTUS_LIBP2P_LISTENADDRESSES`
- document the new environment variables for the Nomad job
- note listen address change in the changelog

## Testing
- `go test ./...` *(fails: open /workspace/lotus/extern/filecoin-ffi/go.mod: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687cd97c692483219a8891141e80a633